### PR TITLE
use headers instead of cookies

### DIFF
--- a/lib/API_Fuzzer.rb
+++ b/lib/API_Fuzzer.rb
@@ -23,7 +23,7 @@ module API_Fuzzer
     vulnerabilities << API_Fuzzer::SqlBlindCheck.scan(options)
     vulnerabilities << API_Fuzzer::RedirectCheck.scan(options)
     vulnerabilities << API_Fuzzer::IdorCheck.scan(options)
-    vulnerabilities << API_Fuzzer::RateLimitCheck(options)
+    vulnerabilities << API_Fuzzer::RateLimitCheck.scan(options)
     API_Fuzzer::XxeCheck.scan(options)
     vulnerabilities.uniq.flatten
   end

--- a/lib/API_Fuzzer/idor_check.rb
+++ b/lib/API_Fuzzer/idor_check.rb
@@ -9,6 +9,7 @@ module API_Fuzzer
         @url = options[:url]
         @params = options[:params]
         @methods = options[:method]
+        @headers = options[:headers] || {}
         @cookies = options[:cookies]
         @vulnerabilities = []
 
@@ -22,6 +23,7 @@ module API_Fuzzer
             url: @url,
             params: @params,
             method: method,
+            headers: @headers,
             cookies: @cookies
           )
 

--- a/lib/API_Fuzzer/rate_limit_check.rb
+++ b/lib/API_Fuzzer/rate_limit_check.rb
@@ -6,6 +6,7 @@ module API_Fuzzer
     def self.scan(options = {})
       @url = options[:url]
       @params = options[:params] || {}
+      @headers = options[:headers] || {}
       @cookies = options[:cookies] || {}
       @vulnerabilities = []
       @limit = options[:limit] || 50
@@ -24,6 +25,7 @@ module API_Fuzzer
           url: @url,
           method: method,
           cookies: @cookies,
+          headers: @headers,
           params: @params
         )
       end
@@ -55,6 +57,7 @@ module API_Fuzzer
         url: @url,
         method: method,
         cookies: @cookies,
+        headers: @headers,
         params: @params
       )
     end

--- a/lib/API_Fuzzer/redirect_check.rb
+++ b/lib/API_Fuzzer/redirect_check.rb
@@ -13,6 +13,7 @@ module API_Fuzzer
         @params = options[:params] || {}
         @cookies = options[:cookies] || {}
         @json = options[:json] || false
+        @headers = options[:headers] || {}
 
         @vulnerabilities = []
         fuzz_payload
@@ -56,7 +57,8 @@ module API_Fuzzer
               url: url,
               method: method,
               cookies: @cookies,
-              params: @params
+              params: @params,
+              headers: @headers
             )
 
             @vulnerabilities << API_Fuzzer::Vulnerability.new(
@@ -80,7 +82,8 @@ module API_Fuzzer
               url: @url,
               method: method,
               cookies: @cookies,
-              params: params
+              params: params,
+              headers: @headers
             )
 
             @vulnerabilities << API_Fuzzer::Vulnerability.new(

--- a/lib/API_Fuzzer/request.rb
+++ b/lib/API_Fuzzer/request.rb
@@ -11,7 +11,7 @@ module API_Fuzzer
         @method = options.delete(:method) || :get
         @json = options.delete(:json) ? true : false
         @body = options.delete(:body) ? true : false
-        @request = set_cookies(options)
+        @request = set_cookies_headers(options)
         send_request
       end
     end
@@ -26,12 +26,10 @@ module API_Fuzzer
 
     private
 
-    def self.set_cookies(options = {})
+    def self.set_cookies_headers(options = {})
       cookies = options.delete(:cookies) || {}
-      request_object = HTTP.cookies('api_fuzzer' => true).headers("Content-Type" => "application/xml")
-      cookies.each do |cookie, value|
-        request_object.cookies(cookie, value)
-      end
+      headers = options.delete(:headers) || {}
+      request_object = HTTP.headers(headers).cookies(cookies)
       request_object
     end
 

--- a/lib/API_Fuzzer/sql_blind_check.rb
+++ b/lib/API_Fuzzer/sql_blind_check.rb
@@ -28,7 +28,8 @@ module API_Fuzzer
           url: @url,
           params: @params,
           method: method,
-          cookies: @cookies
+          cookies: @cookies,
+          headers: @headers
         )
         end_time = Time.now
         diff = end_time - start_time

--- a/lib/API_Fuzzer/sql_check.rb
+++ b/lib/API_Fuzzer/sql_check.rb
@@ -22,6 +22,7 @@ module API_Fuzzer
       @params = options[:params] || {}
       @cookies = options[:cookies] || {}
       @json = options[:json] || false
+      @headers = options[:headers] || {}
       @vulnerabilities = []
 
       fuzz_payloads
@@ -67,7 +68,8 @@ module API_Fuzzer
           response = API_Fuzzer::Request.send_api_request(
             url: url,
             method: method,
-            cookies: @cookies
+            cookies: @cookies,
+            headers: @headers
           )
 
           @vulnerabilities << API_Fuzzer::Error.new(description: "#{method} #{@url}", status: response.status, value: response.body) unless success?(response)
@@ -100,7 +102,8 @@ module API_Fuzzer
             url: @url,
             params: @params,
             method: method,
-            cookies: @cookies
+            cookies: @cookies,
+            headers: @headers
           )
 
           @vulnerabilities << API_Fuzzer::Error.new(description: "[ERROR] #{method} #{@url}", status: response.status, value: response.body) unless success?(response)

--- a/lib/API_Fuzzer/xss_check.rb
+++ b/lib/API_Fuzzer/xss_check.rb
@@ -18,6 +18,7 @@ module API_Fuzzer
       raise InvalidURLError, "[ERROR] URL missing in argument" unless @url
       @params = options[:params] || {}
       @cookies = options[:cookies] || {}
+      @headers = options[:headers] || {}
       @json = options[:json] || false
       @vulnerabilities = []
 
@@ -44,7 +45,8 @@ module API_Fuzzer
           url: @url,
           params: @params,
           method: method,
-          cookies: @cookies
+          cookies: @cookies,
+          headers: @headers
         )
 
         if response_json?(response)

--- a/lib/API_Fuzzer/xxe_check.rb
+++ b/lib/API_Fuzzer/xxe_check.rb
@@ -9,6 +9,8 @@ module API_Fuzzer
       @url = options[:url] || nil
       @params = options[:params]
       @scan_hash = options[:scan]
+      @cookies = options[:cookies] || {}
+      @headers = options[:headers] || {}
       fuzz_xml_params
     end
 
@@ -28,7 +30,9 @@ module API_Fuzzer
         url: @url,
         params: payload,
         body: true,
-        method: :post
+        method: :post,
+        headers: @headers,
+        cookies: @cookies
       )
     end
 


### PR DESCRIPTION
Use headers instead of cookies and reduce ambiguity 